### PR TITLE
Add support for encoding/decoding URIs, plus tests

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This release adds support for encoding and decoding of `java.net.URI` instances
+with `JsonUtil`.

--- a/src/main/scala/uk/ac/wellcome/json/JsonUtil.scala
+++ b/src/main/scala/uk/ac/wellcome/json/JsonUtil.scala
@@ -11,10 +11,10 @@ import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import scala.util.Try
 
 object JsonUtil
-  extends AutoDerivation
-  with TimeInstances
-  with Logging
-  with URIConverters {
+    extends AutoDerivation
+    with TimeInstances
+    with Logging
+    with URIConverters {
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults

--- a/src/main/scala/uk/ac/wellcome/json/JsonUtil.scala
+++ b/src/main/scala/uk/ac/wellcome/json/JsonUtil.scala
@@ -10,7 +10,11 @@ import uk.ac.wellcome.json.exceptions.JsonDecodingError
 
 import scala.util.Try
 
-object JsonUtil extends AutoDerivation with TimeInstances with Logging with URIConverters {
+object JsonUtil
+  extends AutoDerivation
+  with TimeInstances
+  with Logging
+  with URIConverters {
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults

--- a/src/main/scala/uk/ac/wellcome/json/JsonUtil.scala
+++ b/src/main/scala/uk/ac/wellcome/json/JsonUtil.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.json.exceptions.JsonDecodingError
 
 import scala.util.Try
 
-object JsonUtil extends AutoDerivation with TimeInstances with Logging {
+object JsonUtil extends AutoDerivation with TimeInstances with Logging with URIConverters {
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults

--- a/src/main/scala/uk/ac/wellcome/json/URIConverters.scala
+++ b/src/main/scala/uk/ac/wellcome/json/URIConverters.scala
@@ -1,0 +1,22 @@
+package uk.ac.wellcome.json
+
+import java.net.{URI, URISyntaxException}
+
+import io.circe.{Decoder, DecodingFailure, Encoder}
+
+private[json] trait URIConverters {
+  implicit val uriEncoder: Encoder[URI] =
+    Encoder.encodeString.contramap[URI](_.toString)
+
+  implicit val uriDecoder: Decoder[URI] = Decoder.instance { cursor =>
+    cursor.as[String] match {
+      case Right(str) =>
+        try Right(new URI(str))
+        catch {
+          case _: URISyntaxException =>
+            Left(DecodingFailure("URI", cursor.history))
+        }
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[URI]]
+    }
+  }
+}

--- a/src/test/scala/uk/ac/wellcome/json/JsonUtilTest.scala
+++ b/src/test/scala/uk/ac/wellcome/json/JsonUtilTest.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.json
 
+import java.net.URI
+
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
@@ -46,7 +48,6 @@ class JsonUtilTest extends FunSpec with Matchers with JsonAssertions {
       triedA.isFailure shouldBe true
       triedA.failed.get shouldBe a[JsonDecodingError]
     }
-
   }
 
   describe("toJson") {
@@ -72,4 +73,37 @@ class JsonUtilTest extends FunSpec with Matchers with JsonAssertions {
     }
   }
 
+  describe("URI conversion") {
+    case class Website(title: String, uri: URI)
+
+    it("converts a URI to JSON") {
+      val website = Website(
+        title = "Wellcome Collection",
+        uri = new URI("https://wellcomecollection.org/")
+      )
+
+      assertJsonStringsAreEqual(
+        toJson(website).get,
+        """
+          |{
+          |  "title": "Wellcome Collection",
+          |  "uri": "https://wellcomecollection.org/"
+          |}
+        """.stripMargin
+      )
+    }
+
+    it("serialises a JSON string as a URI") {
+      val jsonString =
+        """
+          |{
+          |  "title": "JSON",
+          |  "uri": "https://json.org/"
+          |}
+        """.stripMargin
+
+      val website = fromJson[Website](jsonString).get
+      website.uri shouldBe new URI("https://json.org/")
+    }
+  }
 }

--- a/src/test/scala/uk/ac/wellcome/json/JsonUtilTest.scala
+++ b/src/test/scala/uk/ac/wellcome/json/JsonUtilTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.json
 
 import java.net.URI
+import java.util.UUID
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
@@ -105,5 +106,44 @@ class JsonUtilTest extends FunSpec with Matchers with JsonAssertions {
       val website = fromJson[Website](jsonString).get
       website.uri shouldBe new URI("https://json.org/")
     }
+  }
+
+  describe("UUID conversion") {
+    case class Shipment(name: String, id: UUID)
+
+    it("converts a shipment to JSON") {
+      val uuid = uuidFromString("transport")
+      val shipment = Shipment(
+        name = "Red cars and yellow cars",
+        id = uuid
+      )
+
+      assertJsonStringsAreEqual(
+        toJson(shipment).get,
+        s"""
+          |{
+          |  "name": "Red cars and yellow cars",
+          |  "id": "${uuid.toString}"
+          |}
+        """.stripMargin
+      )
+    }
+
+    it("serialises a JSON string as a URI") {
+      val uuid = uuidFromString("electronics")
+      val jsonString =
+        s"""
+          |{
+          |  "name": "Laptops and phones",
+          |  "id": "${uuid.toString}"
+          |}
+        """.stripMargin
+
+      val website = fromJson[Shipment](jsonString).get
+      website.id shouldBe uuid
+    }
+
+    def uuidFromString(s: String): UUID =
+      UUID.nameUUIDFromBytes(s.getBytes())
   }
 }


### PR DESCRIPTION
This will allow us to get this code out of the platform repo, and share it around.

(Also, turns out Circe already has support for UUIDs!)